### PR TITLE
Fixed Windows Build

### DIFF
--- a/build-all.bat
+++ b/build-all.bat
@@ -3,10 +3,10 @@ setlocal EnableDelayedExpansion
 
 set CMAKE_BUILD_PARALLEL_LEVEL=%NUMBER_OF_PROCESSORS%
 
-cmake %* %CMAKE_FLAGS% -B build src
+cmake %* %CMAKE_FLAGS% -DCMAKE_CONFIGURATION_TYPES="Debug;Release" -B build src
 if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
 
-cmake --build build --target build_external_libraries
+cmake --build build --config Release --target build_external_libraries
 if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
 
 cmake build

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,8 +14,11 @@ option(WITH_CUDA "WITH_CUDA" OFF)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH on)
 
 if (WIN32)
+  if (MSVC)
+    add_compile_options(/bigobj)
+  endif()
   if (NOT CMAKE_MSVC_RUNTIME_LIBRARY)
-    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded")
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
   endif()
 endif()
 


### PR DESCRIPTION
Multi Configuration Generators such as Visual Studio require CMAKE_CONFIGURATION_TYPES from command line when used with --config switch.